### PR TITLE
Add an option to specify the AMC slot instead of the IPMB address

### DIFF
--- a/mmcterm/mmcterm.py
+++ b/mmcterm/mmcterm.py
@@ -474,8 +474,8 @@ def main():
                         help='IP address or hostname of MCH'
                         )
     parser.add_argument('mmc_addr',
-                        type=lambda x: int(x, 0),
-                        help='IPMB-L address of MMC'
+                        type=lambda s: 0x70 + 2*int(s[3:], 0) if s.find("AMC") == 0 else int(s, 0),
+                        help='IPMB-L address of MMC or "AMCn" (n=1..12)'
                         )
     parser.add_argument('-v', '--version',
                         action='version',


### PR DESCRIPTION
This pull requests improves the usability a little bit by allowing the user to specify the AMC slot (in the format of "AMCn") instead of IPMB address, and the tool automatically performs the translation in accordance with the Table 3-5 from MicroTCA.0 standard.